### PR TITLE
Fix problem with Fusion 7 and HGFS kernel module

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.6.5"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/ubuntu-14.04"
+  config.vm.box = "boxcutter/ubuntu1404"
   config.vm.box_check_update = true
 
   # Ports for http, https, Express, http-server and Harp


### PR DESCRIPTION
I have tried to spin up the Vagrant box with VMware Fusion 7, but I got an error that the HGFS kernel module could not be loaded.

I'm using Vagrant 1.7.2 and VMware Fusion 7.1.1 on OSX 10.10.3. Here is the output of my `vagrant up` run:

```
$ vagrant up --provider vmware_fusion
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Box 'chef/ubuntu-14.04' could not be found. Attempting to find and install...
    default: Box Provider: vmware_desktop, vmware_fusion, vmware_workstation
    default: Box Version: >= 0
==> default: Loading metadata for box 'chef/ubuntu-14.04'
    default: URL: https://atlas.hashicorp.com/chef/ubuntu-14.04
==> default: Adding box 'chef/ubuntu-14.04' (v1.0.0) for provider: vmware_desktop
    default: Downloading: https://atlas.hashicorp.com/chef/boxes/ubuntu-14.04/versions/1.0.0/providers/vmware_desktop.box
==> default: Successfully added box 'chef/ubuntu-14.04' (v1.0.0) for 'vmware_desktop'!
==> default: Cloning VMware VM: 'chef/ubuntu-14.04'. This can take some time...
==> default: Checking if box 'chef/ubuntu-14.04' is up to date...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 192.168.254.135:22
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if its present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Forwarding ports...
    default: -- 80 => 80
    default: -- 443 => 443
    default: -- 3000 => 3000
    default: -- 8080 => 8080
    default: -- 9000 => 9000
    default: -- 27017 => 27017
    default: -- 28017 => 28017
    default: -- 5672 => 5672
    default: -- 15672 => 15672
    default: -- 22 => 2222
==> default: Configuring network adapters within the VM...
==> default: Waiting for HGFS kernel module to load...
The HGFS kernel module was not found on the running virtual machine.
This must be installed for shared folders to work properly. Please
install the VMware tools within the guest and try again. Note that
the VMware tools installation will succeed even if HGFS fails
to properly install. Carefully read the output of the VMware tools
installation to verify the HGFS kernel modules were installed properly.
```

It might be that the `chef/ubuntu14.04` box version 1.0.0 is slightly outdated. So I took another Ubuntu 14.04 basebox. The maintainers at boxcutter more often do some updates to their base boxes.

Here is the `vagrant up` run with the `boxcutter/ubuntu1404` box version 1.0.17:

```
$ vagrant up --provider vmware_fusion
WARNING: Could not load IOV methods. Check your GSSAPI C library for an update
WARNING: Could not load AEAD methods. Check your GSSAPI C library for an update
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Box 'boxcutter/ubuntu1404' could not be found. Attempting to find and install...
    default: Box Provider: vmware_desktop, vmware_fusion, vmware_workstation
    default: Box Version: >= 0
==> default: Loading metadata for box 'boxcutter/ubuntu1404'
    default: URL: https://atlas.hashicorp.com/boxcutter/ubuntu1404
==> default: Adding box 'boxcutter/ubuntu1404' (v1.0.17) for provider: vmware_desktop
    default: Downloading: https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404/versions/1.0.17/providers/vmware_desktop.box
==> default: Successfully added box 'boxcutter/ubuntu1404' (v1.0.17) for 'vmware_desktop'!
==> default: Cloning VMware VM: 'boxcutter/ubuntu1404'. This can take some time...
==> default: Checking if box 'boxcutter/ubuntu1404' is up to date...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 192.168.254.133:22
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if its present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Forwarding ports...
    default: -- 80 => 80
    default: -- 443 => 443
    default: -- 3000 => 3000
    default: -- 8080 => 8080
    default: -- 9000 => 9000
    default: -- 27017 => 27017
    default: -- 28017 => 28017
    default: -- 5672 => 5672
    default: -- 15672 => 15672
    default: -- 22 => 2222
==> default: Configuring network adapters within the VM...
==> default: Waiting for HGFS kernel module to load...
==> default: Enabling and configuring shared folders...
    default: -- /Users/stefan/code/vagrant-node: /vagrant
    default: -- /Users/stefan/code: /home/vagrant/projects
==> default: Running provisioner: docker...
    default: Installing Docker (1.3) onto machine...
...
```

So this other box seems to be a solution.