### PR TITLE
update docker to version 1.6.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vm.cpus = 2
   end
 
-  config.vm.provision "docker", version: "1.3" do |docker|
+  config.vm.provision "docker", version: "1.6.2" do |docker|
     docker.pull_images "ubuntu"
   end
 


### PR DESCRIPTION
The `Vagrantfile` tries to install Docker 1.3, but there are more patch versions out there. This results in a conflict:

```
    default: Installing Docker (1.3) onto machine...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

apt-get install -y --force-yes -q xz-utils lxc-docker-1.3 -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'

Stdout from the command:

Reading package lists...
Building dependency tree...
xz-utils is already the newest version.
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 lxc-docker-1.3.0 : Conflicts: lxc-docker-virtual-package
 lxc-docker-1.3.1 : Conflicts: lxc-docker-virtual-package
 lxc-docker-1.3.2 : Conflicts: lxc-docker-virtual-package
 lxc-docker-1.3.3 : Conflicts: lxc-docker-virtual-package


Stderr from the command:

stdin: is not a tty
E: Unable to correct problems, you have held broken packages.
```

So I have udpated the line to install Docker 1.6.2 to have the latest Docker in the Vagrant box.
